### PR TITLE
CSI driver v1.1.1 release

### DIFF
--- a/deploy/Centos/ntnx-csi-node.yaml
+++ b/deploy/Centos/ntnx-csi-node.yaml
@@ -44,7 +44,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: ntnx/ntnx-csi:v1.1.0
+          image: ntnx/ntnx-csi:v1.1.1
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/Centos/ntnx-csi-provisioner.yaml
+++ b/deploy/Centos/ntnx-csi-provisioner.yaml
@@ -49,7 +49,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: ntnx-csi-plugin
-        image: ntnx/ntnx-csi:v1.1.0
+        image: ntnx/ntnx-csi:v1.1.1
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/deploy/Ubuntu1804/ntnx-csi-node.yaml
+++ b/deploy/Ubuntu1804/ntnx-csi-node.yaml
@@ -44,7 +44,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: ntnx/ntnx-csi:v1.1.0
+          image: ntnx/ntnx-csi:v1.1.1
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/Ubuntu1804/ntnx-csi-provisioner.yaml
+++ b/deploy/Ubuntu1804/ntnx-csi-provisioner.yaml
@@ -49,7 +49,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: ntnx-csi-plugin
-        image: ntnx/ntnx-csi:v1.1.0
+        image: ntnx/ntnx-csi:v1.1.1
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true


### PR DESCRIPTION
Besides bug fixes, this release brings in support of FQDN in
place of prism external IP and data service IP.