### PR TITLE
bugfix: get rid of duplicated iscsiadm volume mount

### DIFF
--- a/deploy/SLES15SP1/ntnx-csi-node.yaml
+++ b/deploy/SLES15SP1/ntnx-csi-node.yaml
@@ -125,10 +125,6 @@ spec:
           hostPath:
             path: /lib/modules
             type: Directory
-        - name: iscsiadm
-          hostPath:
-            path: /sbin/iscsiadm
-            type: File
         - name: iscsiadmroot
           hostPath:
             path: /


### PR DESCRIPTION
`kubectl create -f .` from directory raise an error about duplicated volume mount.

This patch resolve this issue and has been tested on a rancher installation.