### PR TITLE
Added PSP, updated secret, added storage class, updated README

### DIFF
--- a/deploy/SLES15SP1/README.md
+++ b/deploy/SLES15SP1/README.md
@@ -13,3 +13,21 @@ sudo zypper install open-iscsi
 ## Support AFS
 
 There is no need to install NFS client package on each worker node, because `ntnx/ntnx-csi` container image already has `nfs-client` installed for support Nutanix AFS.
+
+## Apply the files in the following order: 
+1. ntnx-csi-psp.yaml
+2. ntnx-csi-rbac.yaml
+* Verify: 
+** `kubectl get serviceaccounts -n kube-system | grep csi`
+** `kubectl get clusterrole -n kube-system | egrep "csi|runner"`
+** `kubectl get clusterrolebinding -n kube-system | grep csi`
+3. ntnx-csi-node.yaml 
+* Verify: `kubectl get daemonset -n kube-system | grep csi`
+4. ntnx-csi-provisioner.yaml
+* Verify: `kubectl get statefulset -n kube-system | grep csi`
+5. csi-driver.yaml
+6. ntnx-secret.yaml
+* Verify: `kubectl get secret -n kube-system | grep ntnx`
+7. ntnx-volume-storage-class.yaml
+* Verify: `kubectl get storageclass`
+

--- a/deploy/SLES15SP1/ntnx-csi-psp.yaml
+++ b/deploy/SLES15SP1/ntnx-csi-psp.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: ntnx-csi-psp
+spec:
+  allowedHostPaths:
+  - pathPrefix: /var/lib/kubelet/plugins_registry/
+  - pathPrefix: /var/lib/kubelet/plugins/com.nutanix.csi/
+  - pathPrefix: /var/lib/kubelet
+  - pathPrefix: /dev
+  - pathPrefix: /etc/iscsi
+  - pathPrefix: /sbin/iscsiadm
+  - pathPrefix: /lib/modules
+  - pathPrefix: /
+  - pathPrefix: /lib64/ld-linux-x86-64.so.2
+  hostNetwork: true
+  privileged: true
+  allowPrivilegeEscalation: true 
+  volumes:
+  - hostPath
+  - secret
+  - configMap
+  - emptyDir

--- a/deploy/SLES15SP1/ntnx-csi-rbac.yaml
+++ b/deploy/SLES15SP1/ntnx-csi-rbac.yaml
@@ -35,6 +35,14 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups:
+    - extensions
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - ntnx-csi-psp
+    verbs:
+    - use
     
 ---
 kind: ClusterRoleBinding
@@ -93,6 +101,14 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups:
+    - extensions
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - ntnx-csi-psp
+    verbs:
+    - use
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/SLES15SP1/ntnx-secret.yaml
+++ b/deploy/SLES15SP1/ntnx-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+ name: ntnx-secret
+ namespace: kube-system
+data:
+ # key is base64 encoded string of prism-ip:prism-port:admin:password
+ # E.g.: echo -n "10.6.47.155:9440:admin:mypassword" | base64
+ key: 

--- a/deploy/SLES15SP1/ntnx-volume-storage-class.yaml
+++ b/deploy/SLES15SP1/ntnx-volume-storage-class.yaml
@@ -1,0 +1,26 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: acs-abs
+# Uncomment the following two lines to make this the default storage class
+#    annotations:
+#      storageclass.kubernetes.io/is-default-class: "true"
+provisioner: com.nutanix.csi
+parameters:
+# provisioner-secret-name and provisioner-secret-namespace come from ntnx-secret.yaml
+    csi.storage.k8s.io/provisioner-secret-name: ntnx-secret
+    csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+    csi.storage.k8s.io/node-publish-secret-name: ntnx-secret
+    csi.storage.k8s.io/node-publish-secret-namespace: kube-system
+    csi.storage.k8s.io/controller-expand-secret-name: ntnx-secret
+    csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
+    csi.storage.k8s.io/fstype: ext4
+# dataServiceEndPoint IP is found in the Prisim UI under Settings -> Cluster Details
+# dataServiceEndPoint port is the port used for iSCSI, normally 3260
+    dataServiceEndPoint: <IP>:<port>
+# storageContainer name is found in the Prisim UI under Storage -> Storage Containers (use the search box, as needed)
+    storageContainer: <Storage Container Name>
+    storageType: NutanixVolumes
+allowVolumeExpansion: true
+# reclaimPolicy can be Delete or Reclaim
+reclaimPolicy: Delete


### PR DESCRIPTION
Found that a PSP is required to support the privileges needed by the service accounts. Created a PSP that closely matches the needs of Daemon Set and Stateful Set. Unfortunately, I won't be able to test this for several weeks.

Updated the secret to put it in kube-system by default.

Added a Storage Class with comments inline to guide the user in finding the correct settings

Updated the README to include consolidated steps to deploy.